### PR TITLE
[fix] add user group to manage apkbuild properly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,10 +12,14 @@ RUN echo "$USERNAME:$USERNAME" | chpasswd
 RUN echo "$USERNAME     ALL=(ALL) ALL" > /etc/sudoers
 RUN echo 'PACKAGER="$PACKAGER"' > /etc/abuild.conf
 
+RUN addgroup $USERNAME abuild
+
 RUN mkdir -p /var/cache/distfiles
 RUN chmod a+w /var/cache/distfiles
 RUN chgrp abuild /var/cache/distfiles 
 RUN chmod g+w /var/cache/distfiles
+
+RUN chmod 777 /home/packager
 
 USER $USERNAME
 WORKDIR /home/packager


### PR DESCRIPTION
##### SUMMARY
<!--- Describe the change, including rationale and design decisions -->
fix user right on apkbuild usages
<!---
If you are fixing an existing issue, please include "Fixes #nnn" in your
commit message and your description; but you should still explain what
the change does.
-->

##### ISSUE TYPE
<!--- Pick one below and delete the rest: -->
 - Bugfix Pull Request

##### COMPONENT NAME
<!--- Name of the component that receive modifications -->
Dockerfile
##### VERSION
<!--- Paste verbatim output from "docker run --rm 4383/apkbuild version" between quotes below -->
```
devel
```


##### ADDITIONAL INFORMATION
<!---
Include additional information to help people understand the change here.
For bugs that don't have a linked bug report, a step-by-step reproduction
of the problem is helpful.
  -->

<!--- Paste verbatim command output below, e.g. before and after your change -->
before changes
```
abuild checksum
>>> WARNING: py-virtualenvwrapper: REPODEST is not set and is now required. Defaulting to ~/packages
sed: can't create temp file '/home/packager/APKBUILDXXXXXX': Permission denied
>>> ERROR: py-virtualenvwrapper: checksum failed
```

after changes
```
abuild checksum
```